### PR TITLE
Use Fecooo's APIs for built-in emotes and packs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ After completing the authorization, start the process and the program will open 
 - Liqutch for the [original Python version this is based on][upstream]!
 - xMistt's [DeviceAuthGenerator]
 - LeleDerGrasshalmi's [Epic Games API Documentation][endpoints]
+- Fecooo for [the use of their APIs][fecooo]
 
 [latest]: https://github.com/RuiNtD/FNGG-LockerGenerator/releases/latest
 [upstream]: https://github.com/Liqutch/FNGG-LockerGenerator
 [DeviceAuthGenerator]: https://github.com/xMistt/DeviceAuthGenerator
 [endpoints]: https://github.com/LeleDerGrasshalmi/FortniteEndpointsDocumentation/tree/main/EpicGames/FN-Service/Game/Profile
+[fecooo]: https://github.com/Fecooo/FNGGLocker/issues/2

--- a/src/apis/FNAPI.ts
+++ b/src/apis/FNAPI.ts
@@ -16,4 +16,5 @@ async function _getFNAPICosmetics() {
   const { data } = await axios.get("https://fortnite-api.com/v2/cosmetics/br");
   return v.parse(FNAPICosmetics, data);
 }
+/** @deprecated */
 export const getFNAPICosmetics = pMemoize(_getFNAPICosmetics);

--- a/src/apis/FNGG.ts
+++ b/src/apis/FNGG.ts
@@ -55,6 +55,7 @@ export const getFNGGBundles = pMemoize(_getFNGGBundles);
 
 const cacheDir = cache.join("packs");
 const PackCache = v.array(v.string());
+/** @deprecated */
 export async function getPackContents(id: string | number) {
   const cacheFile = cacheDir.join(`${id}.json`);
   const cacheData = v.safeParse(PackCache, await cacheFile.readMaybeJson());

--- a/src/apis/fecooo.ts
+++ b/src/apis/fecooo.ts
@@ -1,0 +1,19 @@
+import axios from "axios";
+import * as v from "valibot";
+import pMemoize from "p-memoize";
+
+const FecoooOffers = v.record(v.string(), v.number());
+
+async function _getFecoooOffers() {
+  const { data } = await axios.get("https://api.fecooo.hu/fngg/offers");
+  return v.parse(FecoooOffers, await data);
+}
+export const getFecoooOffers = pMemoize(_getFecoooOffers);
+
+const FecoooBuiltins = v.record(v.string(), v.string());
+
+async function _getFecoooBuiltins() {
+  const { data } = await axios.get("https://api.fecooo.hu/fngg/builtins");
+  return v.parse(FecoooBuiltins, await data);
+}
+export const getFecoooBuiltins = pMemoize(_getFecoooBuiltins);

--- a/src/apis/fecooo.ts
+++ b/src/apis/fecooo.ts
@@ -2,6 +2,9 @@ import axios from "axios";
 import * as v from "valibot";
 import pMemoize from "p-memoize";
 
+// APIs provided by Fecooo on GitHub:
+// https://github.com/Fecooo/FNGGLocker
+
 const FecoooOffers = v.record(v.string(), v.number());
 
 async function _getFecoooOffers() {


### PR DESCRIPTION
Reduces the number of calls to Fortnite.GG and eliminates the use of Fortnite-API.com (downloads 11 MB per run BTW 😅) in favor of an alternative API made [for this exact purpose](https://github.com/Fecooo/FNGGLocker).
Blocked by https://github.com/Fecooo/FNGGLocker/issues/2